### PR TITLE
Fixed include guard in SimpleList.h

### DIFF
--- a/SimpleList.h
+++ b/SimpleList.h
@@ -1,5 +1,5 @@
 #ifndef SIMPLELIST_H
-#define LIMPLELIST_H
+#define SIMPLELIST_H
 
 #include <cstddef>
 


### PR DESCRIPTION
You seem to have a typo that makes one of the include guards ineffective.